### PR TITLE
getting rid of redundant status file

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -11,7 +11,6 @@ git checkout --orphan gh-pages
 rm .gitignore
 echo 'node_modules/' >> .gitignore
 echo '.DS_Store' >> .gitignore
-date > last-built.txt
 git add .
 git commit -m 'AUTOMATED BUILD AND DEPLOY.'
 git push mozilla gh-pages -f


### PR DESCRIPTION
This is already covered in the healthcheck...

http://mozilla.github.io/mozmaker-templates/demo/healthcheck.txt
